### PR TITLE
Update default LLM to claude-opus-4-8 and bump manifest versions to 6.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
         "description": "Knowledge infrastructure for AI agents - universal references, multi-tier caching, storage abstraction",
-        "version": "6.0.1",
+        "version": "6.0.2",
         "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
             "name": "fractary-codex",
             "source": "./plugins/codex",
             "description": "Project documentation and org-wide synchronization to and from organization central codex",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "author": {
                 "name": "The Fractary",
                 "url": "https://github.com/fractary"

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-codex",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Knowledge retrieval and documentation sync - self-managing memory fabric with MCP integration. Reference docs via codex:// URIs (auto-fetched by MCP). Sync projects bidirectionally with central codex repository.",
   "skills": "./skills/"
 }

--- a/plugins/codex/plugin.json
+++ b/plugins/codex/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://fractary.com/schemas/plugin-manifest-v1.json",
   "name": "@fractary/codex-plugin",
-  "version": "6.0.0",
+  "version": "6.0.2",
   "description": "Memory and knowledge management - Organizational knowledge base with cache and sync",
   "author": "Fractary Team",
   "homepage": "https://github.com/fractary/plugins",
@@ -93,7 +93,7 @@
   "config": {
     "default_llm": {
       "provider": "anthropic",
-      "model": "claude-opus-4-6"
+      "model": "claude-opus-4-8"
     }
   }
 }


### PR DESCRIPTION
## Summary

Audited the plugin's agents, skills, and commands for pinned Claude model IDs and updated them to their latest equivalents, then bumped the manifest versions.

### Model updates
- `plugins/codex/plugin.json` — `config.default_llm.model`: `claude-opus-4-6` → `claude-opus-4-8` (latest Opus)
- Archived commands (`plugins/codex/commands-archived/*.md`) pin `claude-haiku-4-5`, which is still the current Haiku — left unchanged
- Skills contain no model references; no agents directory exists

### Version bumps (aligned at 6.0.2)
- `plugins/codex/plugin.json`: 6.0.0 → 6.0.2 (was lagging the other manifests)
- `plugins/codex/.claude-plugin/plugin.json`: 6.0.1 → 6.0.2
- `.claude-plugin/marketplace.json`: metadata + plugin entry 6.0.1 → 6.0.2

### Verification
- All three edited files pass `python3 -m json.tool`
- No remaining `claude-opus-4-6` references under `plugins/`

https://claude.ai/code/session_01G9HBoT7CpGC2Jg1ZyBAw8f

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9HBoT7CpGC2Jg1ZyBAw8f)_